### PR TITLE
Add Docker option for compiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM devkitpro/devkitarm:latest
+MAINTAINER jski "jski185@gmail.com"
+
+ADD . /
+
+ENTRYPOINT ["make"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Put `ReiNX` folder on the root of your switch's SD card and run `ReiNX.bin` with
 
 You'll need devkitpro with devkitARM and run `make`
 
+To compile with Docker, `chmod +x docker-build.sh` and run the shell script `./docker-build.sh`. This will compile without requiring installation of DevKit* dependencies.
+
 
 **Features:**
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+ECHO ""
+ECHO "Emptying out /build and /out folders..."
+ECHO ""
+rm -rf ./build
+rm -rf ./out
+
+ECHO ""
+ECHO "Building docker image locally..."
+ECHO ""
+docker build . -t reinx-builder:latest
+
+ECHO ""
+ECHO "Running image and generating build..."
+ECHO ""
+docker run -v $(pwd)/build:/build -v $(pwd)/out:/out reinx-builder:latest


### PR DESCRIPTION
Will introduce requirement of Docker to run Linux containers, but will no longer need to install dependencies past that to compile source locally.