### PR TITLE
Bump up version displayed on bootloader to right one

### DIFF
--- a/src/firmware.c
+++ b/src/firmware.c
@@ -25,7 +25,7 @@
 #include "firmware.h"
 #include "kippatches.h"
 
-#define VERSION "v0.1"
+#define VERSION "v1.0"
 
 static pk11_offs *pk11Offs = NULL;
 


### PR DESCRIPTION
Hey, just realized that bootloader still says "Welcome to ReiNX v0.1" instead of v1.0 which is the current version of ReiNX (at least according to git tags).

This fixes that incorrect behavior. 


:)