### PR TITLE
Fix hang when SD card fails to init

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -31,6 +31,6 @@ void panic() {
 
 void error(char *errStr) {
     gfx_con_setcol(&gfx_con, RED, 0, 0);
-    print(strcat("Error: ", errStr));
+    print("Error: %s", errStr);
     gfx_con_setcol(&gfx_con, ORANGE, 0, 0);
 }

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -400,7 +400,9 @@ void firmware() {
 
     if (!sd_mount()) {
         error("Failed to init SD card!\n");
-        return;
+        print("Press any key to power off\n");
+        btn_wait();
+        i2c_send_byte(I2C_5, 0x3C, MAX77620_REG_ONOFFCNFG1, MAX77620_ONOFFCNFG1_PWR_OFF);
     }
 
     print("Welcome to ReiNX %s!\n", VERSION);

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -398,11 +398,12 @@ void firmware() {
     gfx_con_init(&gfx_con, &gfx_ctxt);
     gfx_con_setcol(&gfx_con, ORANGE, 0, 0);
 
-    if (!sd_mount()) {
+    while (!sd_mount()) {
         error("Failed to init SD card!\n");
-        print("Press any key to power off\n");
+        print("Press POWER to power off, any other key to retry\n");
+        if (btn_wait() & BTN_POWER)
+            i2c_send_byte(I2C_5, 0x3C, MAX77620_REG_ONOFFCNFG1, MAX77620_ONOFFCNFG1_PWR_OFF);
         btn_wait();
-        i2c_send_byte(I2C_5, 0x3C, MAX77620_REG_ONOFFCNFG1, MAX77620_ONOFFCNFG1_PWR_OFF);
     }
 
     print("Welcome to ReiNX %s!\n", VERSION);


### PR DESCRIPTION
Adds an option to power off after SD card fails to init. This most often happens if you forget to insert SD card - previously you had to force a hard reset manually. This makes it a bit easier.

Fixes https://github.com/Reisyukaku/ReiNX/issues/30