### PR TITLE
Add ability to load a splash.bmp instead of a .bin

### DIFF
--- a/src/firmware.c
+++ b/src/firmware.c
@@ -42,13 +42,70 @@ static void SE_lock() {
     SE(SE_SECURITY_0) &= 0xFFFFFFFB; // Make access lock regs secure only.
 }
 
-void drawSplash() {
+int drawSplash() {
     // Draw splashscreen to framebuffer.
     if(fopen("/ReiNX/splash.bin", "rb") != 0) {
         fread((void*)0xC0000000, fsize(), 1);
         fclose();
         usleep(3000000);
+        return 0;
     }
+    return -1;
+}
+
+int loadBmp (char * filename) {
+    print("Loading splash.bmp...\n");
+    if (fopen(filename, "rb") == 0)
+        return -1;
+
+    unsigned char * bmp;
+    bmp = malloc(fsize());
+
+    // Read data
+    fread(bmp, fsize(), 1);
+    fclose();
+
+    // Get details of the image & validate them
+    static int size, offset, width, height, colordep;
+    size     = fsize();
+    offset   = (bmp[11] << 8) | bmp[10];
+    width    = (bmp[19] << 8) | bmp[18];
+    height   = (bmp[23] << 8) | bmp[22];
+    colordep =  bmp[28];
+
+    if (width   != 720 
+    || height   != 1280
+    || colordep != 24) {
+        free(bmp);
+        return -1;
+    }
+
+    // Init destination for decoded .bmp
+    unsigned char * out = malloc(0x3C0008);
+    strncpy(out, "00921600", 8);
+
+    // Swap bytes and pad where necessary
+    int index = 8;
+    int pad_counter = 0;
+    for (int i = offset; i < size - offset - 2; i += 3){
+        out[  index  ] = bmp[i + 2];
+        out[index + 1] = bmp[i + 1];
+        out[index + 2] = bmp[  i  ];
+        out[index + 3] = 0;
+        index += 4;
+        pad_counter++;
+        if (pad_counter == 720){
+            index += 192;
+            pad_counter = 0;
+        }
+    }
+    
+    // Finish
+    memcpy((void*)0xC0000000, out, 0x3C0008);
+    free(out);
+    free(bmp);
+    usleep(3000000);
+    return 0;
 }
 
 pk11_offs *pkg11_offsentify(u8 *pkg1) {
@@ -408,6 +465,6 @@ void firmware() {
 
     print("Welcome to ReiNX %s!\n", VERSION);
     loadFirm();
-    drawSplash();
+    (loadBmp("/ReiNX/splash.bmp") == 0) || drawSplash();
     launch();
 }

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -400,6 +400,6 @@ void firmware() {
 
     print("Welcome to ReiNX %s!\n", VERSION);
     loadFirm();
-    (loadBmp("/ReiNX/splash.bmp") == 0) || drawSplash();
+    splash();
     launch();
 }

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -398,8 +398,12 @@ void firmware() {
         btn_wait();
     }
 
+    if(!(btn_read() & BTN_VOL_DOWN)){
+        gfx_con.mute = 1;
+        splash();
+    }
+
     print("Welcome to ReiNX %s!\n", VERSION);
     loadFirm();
-    splash();
     launch();
 }

--- a/src/splash.c
+++ b/src/splash.c
@@ -25,7 +25,6 @@ int drawSplash() {
     if(fopen("/ReiNX/splash.bin", "rb") != 0) {
         fread((void*)0xC0000000, fsize(), 1);
         fclose();
-        usleep(3000000);
         return 0;
     }
     return -1;

--- a/src/splash.c
+++ b/src/splash.c
@@ -1,0 +1,86 @@
+/*
+* Copyright (c) 2018 Reisyukaku
+* Copyright (c) 2018 neonsea
+*
+* This program is free software; you can redistribute it and/or modify it
+* under the terms and conditions of the GNU General Public License,
+* version 2, as published by the Free Software Foundation.
+*
+* This program is distributed in the hope it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stddef.h> 
+#include "splash.h"
+#include "fs.h"
+#include "hwinit.h"
+
+int drawSplash() {
+    // Draw splashscreen to framebuffer.
+    if(fopen("/ReiNX/splash.bin", "rb") != 0) {
+        fread((void*)0xC0000000, fsize(), 1);
+        fclose();
+        usleep(3000000);
+        return 0;
+    }
+    return -1;
+}
+
+int loadBmp(char * filename) {
+    if (fopen(filename, "rb") == 0)
+        return -1;
+
+    unsigned char * bmp;
+    bmp = malloc(fsize());
+
+    // Read data
+    fread(bmp, fsize(), 1);
+    fclose();
+
+    // Get details of the image & validate them
+    static int size, offset, width, height, colordep;
+    size     = fsize();
+    offset   = (bmp[11] << 8) | bmp[10];
+    width    = (bmp[19] << 8) | bmp[18];
+    height   = (bmp[23] << 8) | bmp[22];
+    colordep =  bmp[28];
+
+    if (width   != 720 
+    || height   != 1280
+    || colordep != 24) {
+        free(bmp);
+        return -1;
+    }
+
+    // Init destination for decoded .bmp
+    unsigned char * out = malloc(0x3C0008);
+    strncpy(out, "00921600", 8);
+
+    // Swap bytes and pad where necessary
+    int index = 8;
+    int pad_counter = 0;
+    for (int i = offset; i < size - offset - 2; i += 3){
+        out[  index  ] = bmp[i + 2];
+        out[index + 1] = bmp[i + 1];
+        out[index + 2] = bmp[  i  ];
+        out[index + 3] = 0;
+        index += 4;
+        pad_counter++;
+        if (pad_counter == 720){
+            index += 192;
+            pad_counter = 0;
+        }
+    }
+    
+    // Finish
+    memcpy((void*)0xC0000000, out, 0x3C0008);
+    free(out);
+    free(bmp);
+    usleep(3000000);
+    return 0;
+}

--- a/src/splash.c
+++ b/src/splash.c
@@ -31,8 +31,8 @@ int drawSplash() {
     return -1;
 }
 
-int loadBmp(char * filename) {
-    if (fopen(filename, "rb") == 0)
+int loadBmp() {
+    if (fopen("/ReiNX/splash.bmp", "rb") == 0)
         return -1;
 
     unsigned char * bmp;
@@ -76,11 +76,23 @@ int loadBmp(char * filename) {
             pad_counter = 0;
         }
     }
+
+    // Save to file
+    if(fopen("/ReiNX/splash.bin", "wb") != 0) {
+        fwrite(out, 0x3C0008, 1);
+        fclose();
+    }
     
     // Finish
-    memcpy((void*)0xC0000000, out, 0x3C0008);
     free(out);
     free(bmp);
-    usleep(3000000);
+    drawSplash();
     return 0;
+}
+
+void splash() {
+    if (drawSplash() != 0){
+        // Failed to open splash.bin, try .bmp
+        loadBmp();
+    }
 }

--- a/src/splash.h
+++ b/src/splash.h
@@ -1,0 +1,22 @@
+/*
+* Copyright (c) 2018 Reisyukaku
+* Copyright (c) 2018 neonsea
+*
+* This program is free software; you can redistribute it and/or modify it
+* under the terms and conditions of the GNU General Public License,
+* version 2, as published by the Free Software Foundation.
+*
+* This program is distributed in the hope it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "hwinit/types.h"
+
+int drawSplash();
+int loadBmp(char * filename);

--- a/src/splash.h
+++ b/src/splash.h
@@ -19,4 +19,5 @@
 #include "hwinit/types.h"
 
 int drawSplash();
-int loadBmp(char * filename);
+int loadBmp();
+void splash();


### PR DESCRIPTION
This .bmp needs to be 720x1280 (because of the way the Switch draws gfx) and has to
have a colour depth of 24.

Theoretically, this could be improved by writing the resulting decoded gfx into
splash.bin and loading that directly next time, making it boot faster.

Fixes https://github.com/Reisyukaku/ReiNX/issues/23
