### PR TITLE
Display splash before loading firmware, shave 3 seconds off boot time

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -30,6 +30,7 @@ void panic() {
 }
 
 void error(char *errStr) {
+    gfx_con.mute = 0;
     gfx_con_setcol(&gfx_con, RED, 0, 0);
     print("Error: %s", errStr);
     gfx_con_setcol(&gfx_con, DEFAULT_TEXT_COL, 0, 0);

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -25,13 +25,14 @@
 
 static pk11_offs *pk11Offs = NULL;
 
-void drawSplash() {
+int drawSplash() {
     // Draw splashscreen to framebuffer.
     if(fopen("/ReiNX/splash.bin", "rb") != 0) {
         fread((void*)0xC0000000, fsize(), 1);
         fclose();
-        usleep(3000000);
+        return 1;
     }
+    return 0;
 }
 
 pk11_offs *pkg11_offsentify(u8 *pkg1) {
@@ -309,7 +310,7 @@ void firmware() {
             i2c_send_byte(I2C_5, 0x3C, MAX77620_REG_ONOFFCNFG1, MAX77620_ONOFFCNFG1_PWR_OFF);
         btn_wait();
     }
-    
+
     if(PMC(APBDEV_PMC_SCRATCH49) != 69 && fopen("/ReiNX.bin", "rb")) {
         fread((void*)PAYLOAD_ADDR, fsize(), 1);
         fclose();
@@ -322,9 +323,14 @@ void firmware() {
     }
     SYSREG(AHB_AHB_SPARE_REG) = (volatile vu32)0xFFFFFF9F;
 	PMC(APBDEV_PMC_SCRATCH49) = 0;
-    
+
+    if (btn_read() & BTN_VOL_DOWN) {
+        print("Booting verbosely\n");
+    } else if (drawSplash()) {
+        gfx_con.mute = 1;
+    }
+
     print("Welcome to ReiNX %s!\n", VERSION);
     loadFirm();
-    drawSplash();
     launch();
 }


### PR DESCRIPTION
The way the splash was previously shown was at the very end of the boot chain, but this added an unnecessary 3 seconds to boot time. This commit makes it so the splash is displayed earlier in the boot process, and is displayed while the firmware is being loaded. This makes it still pop up, but without the extra delay.

This means that no boot messages are shown, except for errors. I think this is prettier anyways, however if the user wants to see boot messages, this is still possible by holding volume down while booting, which kicks it into "verbose" mode (don't display splash, display messages).