### PR TITLE
Fix build on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifeq ($(strip $(DEVKITARM)),)
 $(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
 endif
 
-CC = $(DEVKITARM)/bin/arm-none-eabi-gcc
+include $(DEVKITARM)/base_tools
 LD = $(DEVKITARM)/bin/arm-none-eabi-ld
 OBJCOPY = $(DEVKITARM)/bin/arm-none-eabi-objcopy
 


### PR DESCRIPTION
Nice portable way to get `make` to find `libwinpthread-1.dll`, otherwise `make` and `gcc` fail and throw really unhelpful errors (or none at all).