### PR TITLE
Splash flexibility

### DIFF
--- a/src/firmware.c
+++ b/src/firmware.c
@@ -31,8 +31,11 @@ int drawSplash() {
         fread((void*)0xC0000000, fsize(), 1);
         fclose();
         return 1;
-    }
-    return 0;
+    } else if(fopen("/splash.bin", "rb") != 0) {
+        fread((void*)0xC0000000, fsize(), 1);
+        fclose();
+        return 1;
+    } return 0;
 }
 
 pk11_offs *pkg11_offsentify(u8 *pkg1) {


### PR DESCRIPTION
I see some (obviously unfamiliar) people make this simple mistake. Having the option to still have the splash function work properly, even when misplaced, could be helpful to some. Very minor change overall. 