### PR TITLE
changed makefile to put fs_mitm.kip into ReiNX\sysmodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ $(dir_out)/sysmodules: $(dir_sysmod)
 	@cp $(dir_sysmod)/loader/loader.kip $(dir_out)/ReiNX/sysmodules/
 	@cp $(dir_sysmod)/sm/sm.kip $(dir_out)/ReiNX/sysmodules/
 	@cp $(dir_sysmod)/pm/pm.kip $(dir_out)/ReiNX/sysmodules/
-	@cp $(dir_sysmod)/fs_mitm/fs_mitm.kip $(dir_out)/ReiNX/sysmodules.dis/
+	@cp $(dir_sysmod)/fs_mitm/fs_mitm.kip $(dir_out)/ReiNX/sysmodules/
 
 $(dir_out)/$(name).bin: $(dir_build)/$(name).elf
 	@mkdir -p "$(@D)"


### PR DESCRIPTION
Users were having issues booting newest compiled version of ReiNX. Moving fs_mitm.kip from ReiNX\sysmodules.dis to ReiNX\sysmodules fixes this issue