### PR TITLE
heap: Prevent node chain collapse on free

### DIFF
--- a/src/hwinit/heap.c
+++ b/src/hwinit/heap.c
@@ -56,6 +56,7 @@ static u32 _heap_alloc(heap_t *heap, u32 size, u32 alignment)
 			node->used = 1;
 			new->used = 0;
 			new->next = node->next;
+			new->next->prev = new;
 			new->prev = node;
 			node->next = new;
 


### PR DESCRIPTION
On alloc, prev for the following used node never updated to point back at the new unused node